### PR TITLE
add feature auth for login, register

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { UsersModule } from './users/users.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [],
+  imports: [UsersModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,14 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [UsersModule, AuthModule],
+  imports: [ConfigModule.forRoot({
+      isGlobal: true, 
+      envFilePath: '.env',
+    }),
+    UsersModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [PassportModule],
+  providers: [JwtStrategy],
+})
+export class AuthModule {}

--- a/src/auth/jwt-payload.interface.ts
+++ b/src/auth/jwt-payload.interface.ts
@@ -1,0 +1,5 @@
+export interface JwtPayload {
+  sub: number; 
+  username: string;
+  email: string;
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,18 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { JwtPayload } from './jwt-payload.interface';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly configService: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderWithScheme('Token'),
       ignoreExpiration: false,
-      secretOrKey: 'MY_SUPER_SECRET_KEY_123',
+      secretOrKey: configService.get<string>('JWT_SECRET', 'fallback-secret-if-missing'), 
     });
   }
-
-  async validate(payload: { sub: number; username: string; email: string }) {
-    return { sub: payload.sub, username: payload.username, email: payload.email };
+  
+  async validate(payload: JwtPayload) { 
+    return { id: payload.sub, username: payload.username, email: payload.email };
   }
+
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderWithScheme('Token'),
+      ignoreExpiration: false,
+      secretOrKey: 'MY_SUPER_SECRET_KEY_123',
+    });
+  }
+
+  async validate(payload: { sub: number; username: string; email: string }) {
+    return { sub: payload.sub, username: payload.username, email: payload.email };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-
+import { ValidationPipe } from '@nestjs/common'; 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+
+  app.setGlobalPrefix('api');
+
+  app.useGlobalPipes(new ValidationPipe());
+
+  await app.listen(3000);
 }
 bootstrap();

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+
+export class CreateUserDto {
+  @IsNotEmpty({ message: 'Username không được để trống' })
+  username: string;
+
+  @IsEmail({}, { message: 'Email không hợp lệ' })
+  @IsNotEmpty({ message: 'Email không được để trống' })
+  email: string;
+
+  @IsNotEmpty({ message: 'Password không được để trống' })
+  @MinLength(6, { message: 'Password phải có ít nhất 6 ký tự' })
+  password: string;
+}

--- a/src/users/dto/login-user.dto.ts
+++ b/src/users/dto/login-user.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class LoginUserDto {
+  @IsEmail({}, { message: 'Email không hợp lệ' })
+  @IsNotEmpty({ message: 'Email không được để trống' })
+  email: string;
+
+  @IsNotEmpty({ message: 'Password không được để trống' })
+  password: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Post, Body, Get, UseGuards, Request } from '@nestjs/common';
+import { UsersService, UserResponse } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { LoginUserDto } from './dto/login-user.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+class UserRequest<T> {
+  user: T;
+}
+
+@Controller()
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  // Đăng ký: POST /api/users
+  @Post('users')
+  async register(
+    @Body('user') createUserDto: CreateUserDto,
+  ): Promise<{ user: UserResponse }> {
+    const userResponse = await this.usersService.create(createUserDto);
+    return { user: userResponse };
+  }
+
+  // Đăng nhập: POST /api/users/login
+  @Post('users/login')
+  async login(
+    @Body('user') loginUserDto: LoginUserDto,
+  ): Promise<{ user: UserResponse }> {
+    const userResponse = await this.usersService.login(loginUserDto);
+    return { user: userResponse };
+  }
+
+  // Lấy thông tin user hiện tại: GET /api/user
+  @UseGuards(AuthGuard('jwt'))
+  @Get('user')
+  async getCurrentUser(@Request() req): Promise<{ user: UserResponse }> {
+    const user = await this.usersService.findById(req.user.sub);
+    
+    const token = req.headers.authorization.split(' ')[1];
+    
+    return {
+      user: {
+        email: user.email,
+        token: token,
+        username: user.username,
+        bio: user.bio,
+        image: user.image,
+      },
+    };
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,13 +4,17 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-
+import { ConfigModule, ConfigService } from '@nestjs/config'; 
 @Module({
   imports: [
     PassportModule,
-    JwtModule.register({
-      secret: 'MY_SUPER_SECRET_KEY_123',
-      signOptions: { expiresIn: '1d' },
+    JwtModule.registerAsync({ 
+      imports: [ConfigModule], 
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '1d' },
+      }),
+      inject: [ConfigService], 
     }),
   ],
   controllers: [UsersController],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,19 @@
+// src/users/users.module.ts
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.register({
+      secret: 'MY_SUPER_SECRET_KEY_123',
+      signOptions: { expiresIn: '1d' },
+    }),
+  ],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, UnauthorizedException, ConflictException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+import { CreateUserDto } from './dto/create-user.dto';
+import { LoginUserDto } from './dto/login-user.dto';
+
+export type User = any;
+export interface UserResponse {
+  email: string;
+  token: string;
+  username: string;
+  bio: string | null;
+  image: string | null;
+}
+
+@Injectable()
+export class UsersService {
+  private readonly users: User[] = [];
+
+  constructor(private jwtService: JwtService) {}
+
+  private buildUserResponse(user: User): UserResponse {
+    const token = this.jwtService.sign({ 
+        sub: user.id, 
+        username: user.username, 
+        email: user.email 
+    });
+
+    return {
+      email: user.email,
+      token: token,
+      username: user.username,
+      bio: user.bio || null,
+      image: user.image || null,
+    };
+  }
+
+  async create(dto: CreateUserDto): Promise<UserResponse> {
+    const existingUser = this.users.find(u => u.username === dto.username || u.email === dto.email);
+    if (existingUser) {
+      throw new ConflictException('Username hoặc email đã được sử dụng.');
+    }
+
+    const hashedPassword = await bcrypt.hash(dto.password, 10);
+
+    const newUser = {
+      id: Date.now(), 
+      username: dto.username,
+      email: dto.email,
+      password: hashedPassword,
+    };
+    this.users.push(newUser);
+
+    return this.buildUserResponse(newUser);
+  }
+
+  async login(dto: LoginUserDto): Promise<UserResponse> {
+    const user = this.users.find(u => u.email === dto.email);
+
+    if (!user || !(await bcrypt.compare(dto.password, user.password))) {
+      throw new UnauthorizedException('Email hoặc mật khẩu không chính xác.');
+    }
+
+    return this.buildUserResponse(user);
+  }
+
+  async findById(id: number): Promise<User> {
+    return this.users.find(u => u.id === id);
+  }
+}


### PR DESCRIPTION
ready

feat(auth): Triển khai xác thực người dùng bằng JWT

1. TÍNH NĂNG ĐÃ LÀM:
- Xây dựng hệ thống xác thực người dùng cốt lõi bằng JSON Web Token.
- Tạo endpoint `POST /api/users` cho phép người dùng mới đăng ký tài khoản. Mật khẩu được băm (hash) an toàn bằng bcrypt trước khi lưu vào CSDL.
- Tạo endpoint `POST /api/users/login` để người dùng đăng nhập. Sau khi xác thực thông tin thành công, API trả về một JWT đã được ký.
- Tạo một endpoint được bảo vệ `GET /api/user` sử dụng AuthGuard và JwtStrategy để kiểm tra luồng xác thực.


2. KIỂM THỬ NHƯ THẾ NÀO:
- **Đăng ký:** Dùng Postman gửi request `POST` đến `/api/users` với body chứa { "user": { "username": "...", "email": "...", "password": "..." } }. Mong đợi nhận về status `201 Created` và một đối tượng user chứa token.
- **Đăng nhập:** Gửi request `POST` đến `/api/users/login` với email và password đã đăng ký. Mong đợi nhận về status `200 OK` và một token mới.
- **Truy cập tài nguyên được bảo vệ:**
  - Gửi request `GET` đến `/api/user` MÀ KHÔNG có header `Authorization`. Mong đợi nhận về lỗi `401 Unauthorized`.
  - Gửi lại request `GET` đến `/api/user` với header `Authorization: Token <jwt_token_here>`. Mong đợi nhận về status `200 OK` và thông tin của người dùng đã đăng nhập.